### PR TITLE
disable loadOp override on vkCreateRenderpass2 if fastest level

### DIFF
--- a/docs/python_api/renderdoc/shaders.rst
+++ b/docs/python_api/renderdoc/shaders.rst
@@ -111,6 +111,9 @@ Shader Debugging
 .. autoclass:: renderdoc.LineColumnInfo
   :members:
 
+.. autoclass:: renderdoc.InstructionSourceInfo
+  :members:
+
 .. autoclass:: renderdoc.ShaderDebugState
   :members:
 

--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
@@ -2266,7 +2266,8 @@ void D3D12PipelineStateViewer::resource_itemActivated(RDTreeWidgetItem *item, in
       {
         uint32_t bind = (uint32_t)bindArray[i].bind;
         if(bindArray[i].bindset == view.space &&
-           (bind == view.res.bind || (bind <= view.res.bind && bind + arraySize > view.res.bind)))
+           (bind == view.res.bind ||
+            (bind <= view.res.bind && bind + bindArray[i].arraySize > view.res.bind)))
         {
           shaderRes = &resArray[i];
           break;

--- a/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
+++ b/qrenderdoc/Windows/PipelineState/D3D12PipelineStateViewer.cpp
@@ -2264,10 +2264,9 @@ void D3D12PipelineStateViewer::resource_itemActivated(RDTreeWidgetItem *item, in
 
       for(int i = 0; i < bindArray.count(); i++)
       {
+        uint32_t bind = (uint32_t)bindArray[i].bind;
         if(bindArray[i].bindset == view.space &&
-           (bindArray[i].bind == (int)view.res.bind ||
-            (bindArray[i].bind <= (int)view.res.bind &&
-             bindArray[i].bind + bindArray[i].arraySize > (int)view.res.bind)))
+           (bind == view.res.bind || (bind <= view.res.bind && bind + arraySize > view.res.bind)))
         {
           shaderRes = &resArray[i];
           break;


### PR DESCRIPTION
only override loadOp/stencilLoadOp in vkCreateRenderpass2 if we're not in ReplayOptimisationLevel::Fastest, just like the currently-existing code in vkCreateRenderpass2 